### PR TITLE
change all generator names/refs to lowercase

### DIFF
--- a/devtools/create_installer_packages.rst
+++ b/devtools/create_installer_packages.rst
@@ -92,7 +92,7 @@ These kind of tools are not usually part of the application graph itself, they a
 you should usually declare them as :ref:`build requirements <build_requires>`, in the recipe itself or in a profile.
 
 For example, there are many recipes that can take advantage of the ``nasm`` package we've seen above, like 
-`flac <https://conan.io/center/flac/1.3.3/?tab=recipe>`_ or `libx264 <https://conan.io/center/libx264/20191217/?tab=recipe>`_
+`flac <https://conan.io/center/flac?tab=recipe>`_ or `libx264 <https://conan.io/center/libx264?tab=recipe>`_
 that are already available in `ConanCenter <https://conan.io/center/>`_. Those recipes will take advantage of ``nasm`` 
 being in the PATH to run some assembly optimizations.
 

--- a/faq/troubleshooting.rst
+++ b/faq/troubleshooting.rst
@@ -1,6 +1,19 @@
 Troubleshooting
 ==================
 
+ERROR: The recipe is contraining settings
+------------------------------------------
+
+When you install or create a package you might have error like the following one:
+
+.. code-block:: text
+
+    ERROR: The recipe is contraining settings. Invalid setting 'Linux' is not a valid 'settings.os' value.
+    Possible values are ['Windows']
+    Read "http://docs.conan.io/en/latest/faq/troubleshooting.html#error-the-recipe-is-contraining-settings"
+
+This means that your target operating system is not supported by the recipe.
+
 ERROR: Missing prebuilt package
 --------------------------------
 

--- a/howtos/custom_generators.rst
+++ b/howtos/custom_generators.rst
@@ -45,7 +45,7 @@ Create a folder with a new *conanfile.py* with the following contents:
             self.rootpath = "%s" % deps_cpp_info.rootpath.replace("\\", "/")
 
 
-    class Premake(Generator):
+    class premake(Generator):
 
         @property
         def filename(self):
@@ -79,8 +79,8 @@ Create a folder with a new *conanfile.py* with the following contents:
             return "\n".join(sections)
 
 
-    class MyCustomGeneratorPackage(ConanFile):
-        name = "PremakeGen"
+    class MyPremakeGeneratorPackage(ConanFile):
+        name = "premakegen"
         version = "0.1"
         url = "https://github.com/memsharded/conan-premake"
         license = "MIT"
@@ -90,7 +90,7 @@ individual library separately, then also an aggregated information for all depen
 information.
 
 Note the **name of the package** will be **premakegen/0.1@<user>/<channel>** as that is the name given to it, while the generator name is
-**Premake** (the name of the class that inherits from ``Generator``). You can give the package any name you want, even the same as the
+**premake** (the name of the class that inherits from ``Generator``). You can give the package any name you want, even the same as the
 generator's name if desired.
 
 You ``export`` the package recipe to the local cache, so it can be used by other projects as usual:
@@ -130,7 +130,7 @@ Put the following files inside. Note the ``premakegen@0.1@myuser/testing`` packa
     premakegen@0.1@myuser/testing
 
     [generators]
-    Premake
+    premake
 
 .. code-block:: cpp
    :caption: *main.cpp*
@@ -191,7 +191,7 @@ Now everything works, so you might want to share your generator:
 
 .. code-block:: bash
 
-    $ conan upload PremakeGen/0.1@myuser/testing
+    $ conan upload premakegen/0.1@myuser/testing
 
 .. tip::
 
@@ -224,7 +224,7 @@ templating formats:
             return template % "Hello"
 
     class MyCustomGeneratorPackage(ConanFile):
-        name = "custom"
+        name = "custom_generator"
         version = "0.1"
         exports = "mytemplate.txt"
 

--- a/reference/commands/consumer/search.rst
+++ b/reference/commands/consumer/search.rst
@@ -11,6 +11,7 @@ conan search
                    [pattern_or_reference]
 
 Searches package recipes and binaries in the local cache or a remote.
+Unless a remote is specified only the local cache is searched.
 
 If you provide a pattern, then it will search for existing package
 recipes matching it.  If a full reference is provided

--- a/training_courses.rst
+++ b/training_courses.rst
@@ -19,7 +19,7 @@ blog post announcement here:
 For the complete list of dedicated Conan courses, see the Conan series page
 here:  
 
-- https://academy.jfrog.com/series/conan
+- https://academy.jfrog.com/path/conan
 
 Finally, here is a brief video introducing the series:
 


### PR DESCRIPTION
There was one actual error on this doc which has been corrected (the class had uppercase characters but the instructions with the reference was all lowercase. Made class name lowercase to match recommended convention.  Also, updated several other items in the document to be lowercase and/or add cosmetic improvements.